### PR TITLE
Fixed hanging TCP connections after 'Full deploy'

### DIFF
--- a/node-red/velbus-connector.js
+++ b/node-red/velbus-connector.js
@@ -16,6 +16,14 @@ module.exports = function (RED) {
 			this.velbus = new Velbus(config);
 		}
 
+		this.on("close", function () {
+			this.velbus.close();
+			this.velbus.destroy();
+			delete (this.velbus.config);
+            delete (this.velbus);
+			delete (this);
+        });
+
 	}
 
 

--- a/velbus/velbus.js
+++ b/velbus/velbus.js
@@ -222,8 +222,12 @@ class Velbus extends EventEmitter {
 	}
 
 	close() {
-		this.client.close();
-		this.emit("onError", "Velbus client closed");
+		try{
+			this.client.destroy();
+			this.emit("onError", "Velbus client closed");
+		} catch (e) {
+			console.log("ERROR while destroying client:", e);
+		}
 	}
 
 	requestButtonName(address, channel) {


### PR DESCRIPTION
Hi,

I was encountering hanging TCP connections after a complete deploy of all my flows. This resulted in a chain reaction of replies by the hanging connections when the new connection started its 'scan'. Eventually after multiple deploys my bus got flooded and packets with lower priority couldn't be transmitted anymore.

I've written a fix for this issue.
- using the net.Socket 'destroy' function instead of 'close'
- adding a close handler for the velbus-connector to initiate the velbus 'close' and 'destroy' + delete the objects afterwards
